### PR TITLE
Add CLI argument -x/--ctrl-c to terminate program with Ctrl-C

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Usage
 The following command line arguments are supported:
 
 ```
-$ stmux [-h] [-V] [-w <condition>] [-a <activator>] [-t <title>]
+$ stmux [-h] [-V] [-w <condition>] -[x] [-a <activator>] [-t <title>]
         [-c <type>] [-n] [-e <regexp>] [-m <method>] [-M] [-f <file>]
         [-- <spec>]
 ```
@@ -133,6 +133,8 @@ $ stmux [-h] [-V] [-w <condition>] [-a <activator>] [-t <title>]
 - `-w <condition>`, `--wait <condition>`<br/>
   Wait after last finished command (and do not shutdown automatically),
   either if any command terminated with an `error` or just `always`.
+- `-x`, `--ctrl-c`<br/>
+  Terminate program with Ctrl-C (instead of sending it to the subprocess).
 - `-a <activator>`, `--activator <activator>`<br/>
   Use `CTRL+<activator>` as the prefix to special commands.
   The default activator character is `a`.

--- a/src/stmux-1-options.js
+++ b/src/stmux-1-options.js
@@ -29,13 +29,15 @@ export default class stmuxOptions {
     parseOptions () {
         /*  parse command-line arguments  */
         this.argv = yargs
-            .usage("Usage: $0 [-h] [-v] [-w] [-a <activator>] [-t <title>] [-f <file>] [-- <spec>]")
+            .usage("Usage: $0 [-h] [-v] [-w] [-x] [-a <activator>] [-t <title>] [-f <file>] [-- <spec>]")
             .help("h").alias("h", "help").default("h", false)
             .describe("h", "show usage help")
             .boolean("v").alias("v", "version").default("v", false)
             .describe("v", "show program version information")
             .string("w").nargs("w", 1).alias("w", "wait").default("w", "")
             .describe("w", "wait after last finished command (on \"error\" or \"always\")")
+            .boolean("x").alias("x", "ctrl-c").default("x", false)
+            .describe("x", "terminate with Ctrl-C")
             .string("a").nargs("a", 1).alias("a", "activator").default("a", "a")
             .describe("a", "use CTRL+<activator> as the prefix to special commands")
             .string("t").nargs("t", 1).alias("t", "title").default("t", "stmux")

--- a/src/stmux-9-keys.js
+++ b/src/stmux-9-keys.js
@@ -29,6 +29,10 @@ export default class stmuxKeys {
         /*  handle keys  */
         let prefixMode = 0
         this.screen.on("keypress", (ch, key) => {
+            if (this.argv["ctrl-c"] && key.full === "C-c") {
+                this.terminate()
+            }
+
             if ((prefixMode === 0 || prefixMode === 2) && key.full === `C-${this.argv.activator}`) {
                 /*  enter prefix mode  */
                 prefixMode = 1


### PR DESCRIPTION
Hello friends. This is an attempt to solve #1. In my current project I want to run two watch tasks side-by-side for coolness and I want to kill them with a Ctrl-C. This proposed solution works for me.

Please comment and tell me how to improve to better fit the project's standards.