### PR TITLE
Add graceful exit

### DIFF
--- a/src/stmux-7-help.js
+++ b/src/stmux-7-help.js
@@ -57,6 +57,8 @@ export default class stmuxHelp {
                 "restart shell command in focused terminal\n" +
             `CTRL+${this.argv.activator} {bold}{green-fg}k{/green-fg}{/bold} ................... ` +
                 "kill stmux application (and all shell commands)\n" +
+            `CTRL+${this.argv.activator} {bold}{green-fg}c{/green-fg}{/bold} ................... ` +
+                "quit stmux gracefully (send Ctrl-C to all terminals)\n" +
             `CTRL+${this.argv.activator} {bold}{green-fg}?{/green-fg}{/bold} ................... ` +
                 "show (this) help window\n" +
             ""

--- a/src/stmux-7-help.js
+++ b/src/stmux-7-help.js
@@ -58,7 +58,7 @@ export default class stmuxHelp {
             `CTRL+${this.argv.activator} {bold}{green-fg}k{/green-fg}{/bold} ................... ` +
                 "kill stmux application (and all shell commands)\n" +
             `CTRL+${this.argv.activator} {bold}{green-fg}c{/green-fg}{/bold} ................... ` +
-                "quit stmux gracefully (send Ctrl-C to all terminals)\n" +
+                "quit stmux gracefully (and all shell commands)\n" +
             `CTRL+${this.argv.activator} {bold}{green-fg}?{/green-fg}{/bold} ................... ` +
                 "show (this) help window\n" +
             ""

--- a/src/stmux-9-keys.js
+++ b/src/stmux-9-keys.js
@@ -174,6 +174,11 @@ export default class stmuxKeys {
                     /*  kill the program  */
                     this.terminate()
                 }
+                else if (key.full === "c") {
+                    /*  send Ctrl-C to all terminals and disable waiting */
+                    this.argv.wait = ""
+                    this.terms.forEach(term => term.injectInput("\x03"))
+                }
             }
             else if (prefixMode === 2) {
                 /*  leave prefix mode  */


### PR DESCRIPTION
This adds a command `Ctrl-a c` which sends `Ctrl-C` to all terminals in order to make running processes terminate gracefully. It also disables waiting so that stmux terminates automatically after all processes have terminated.

The only current way to quit everything gracefully would be to go through all terminals manually. `Ctrl-a k` will just terminate all children preventing them from cleaning up after themselves. An example would be `docker-compose up` which I tend to use a lot during development. Terminating it will keep containers lingering in the background.

related: #1