### PR TITLE
Fix #23: crashes when no argument given

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,18 +24,25 @@
 
 NPM   = npm
 GRUNT = ./node_modules/grunt-cli/bin/grunt
+BIN = ./bin/stmux.js
+.PHONY: all clean distclean test build
 
-all: build
+all: $(BIN) test
 
-bootstrap:
-	@if [ ! -x $(GRUNT) ]; then $(NPM) install; fi
+test: $(BIN) ./test.sh
+	./test.sh
 
-build: bootstrap
+build: $(BIN)
+
+$(GRUNT):
+	$(NPM) install
+
+$(BIN): src/*.js
 	@$(GRUNT)
 
-clean: bootstrap
+clean: $(GRUNT)
 	@$(GRUNT) clean:clean
 
-distclean: bootstrap
+distclean: $(GRUNT)
 	@$(GRUNT) clean:clean clean:distclean
 

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "node":                                      ">=10.0.0"
     },
     "scripts": {
-        "prepublishOnly": "npm run build",
-        "build":          "grunt default",
-        "test":           "grunt default && ./test.sh"
+        "prepublishOnly": "make",
+        "build":          "make build",
+        "test":           "make test"
     }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "scripts": {
         "prepublishOnly": "npm run build",
         "build":          "grunt default",
-        "test":           "grunt default && node -- ./bin/stmux.js -n -w error -e \"ERROR,!style errors\" -m beep,system -- [ -s 2/3 [ -s 60% -e foo -t shell $SHELL .. 'date; true' ] : 'date; true' ]"
+        "test":           "grunt default && ./test.sh"
     }
 }

--- a/src/stmux-1-options.js
+++ b/src/stmux-1-options.js
@@ -97,7 +97,7 @@ export default class stmuxOptions {
                     }
                     if (bytesRead === 0)
                         break
-                    this.spec += buf.toString(null, 0, bytesRead)
+                    this.spec += buf.toString(undefined, 0, bytesRead)
                 }
             }
             else {

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,10 @@ should_not_crash_on_reading_from_stdin() {
     fi
 }
 
+should_run_basic_use_case(){
+    $STMUX -n -w error -e "ERROR,!style errors" -m beep,system -- [ -s 2/3 [ -s 60% -e foo -t shell $SHELL .. 'date; true' ] : 'date; true' ]
+}
+
 run_all_tests(){
     for f in $(declare -F | grep should_ | sed 's/declare -f//'); do 
         $f || exit 1 # exit on first error

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+STMUX="node ./bin/stmux.js"
+
+should_not_crash_on_reading_from_stdin() {
+    tmp=$(mktemp)
+    (printf '\n' | faketty $STMUX ) > $tmp
+
+    # if everything goes alright, we expect this error message
+    if ! grep 'stmux: ERROR: Expected "\[" but end of input found.' $tmp  > /dev/null ; then
+        echo "Did not find expected output. Got $(cat $tmp)"
+        return 1
+    fi
+}
+
+run_all_tests(){
+    for f in $(declare -F | grep should_ | sed 's/declare -f//'); do 
+        $f || exit 1 # exit on first error
+    done
+}
+
+faketty () {
+  # Create a temporary file for storing the status code
+  tmp=$(mktemp)
+
+  # Ensure it worked or fail with status 99
+  [ "$tmp" ] || return 99
+
+  # Produce a script that runs the command provided to faketty as
+  # arguments and stores the status code in the temporary file
+  cmd="$(printf '%q ' "$@")"'; echo $? > '$tmp
+
+  # Run the script through /bin/sh with fake tty
+  if [ "$(uname)" = "Darwin" ]; then
+    # MacOS
+    script -Fq /dev/null /bin/sh -c "$cmd"
+  else
+    script -qfc "/bin/sh -c $(printf "%q " "$cmd")" /dev/null
+  fi
+
+  # Ensure that the status code was written to the temporary file or
+  # fail with status 99
+  [ -s $tmp ] || return 99
+
+  # Collect the status code from the temporary file
+  err=$(cat $tmp)
+
+  # Remove the temporary file
+  rm -f $tmp
+
+  # Return the status code
+  return $err
+}
+
+run_all_tests


### PR DESCRIPTION
# Intent
The passed in 'null' is an invalid value for encoding when calling [Buffer#toString](https://nodejs.org/api/buffer.html#buftostringencoding-start-end). This fixes #23.

Verified for Node 12-16

# Other changes

It turned out that the Makefile was written in a way that caused the build to re-run always, no matter if files had changed or not, so I fixed the Makefile to only recompute when needed. I also created a test runner in bash to be able to test drive the fix automatically and have a regression test, since I could not see any tests. Only after making this I found that you actually have a little test driver in `npm test`. I moved that as a test into the test runner to keep all the tests in a single location and made NPM delegate to Make for consistency.

# Verification
The following script is executed _after_ checking out this branch and then doing `git checkout 1.8.2 src/stmux-1-options.js` in able to show the bug before and after the fix (but still using the test runner):
<img width="673" alt="Skjermbilde 2021-11-05 kl  23 06 24" src="https://user-images.githubusercontent.com/618076/140583818-a6f7c76e-fb21-4e4e-ac21-4f0eba0bdcb6.png">
